### PR TITLE
Reduce complexity of the workflow

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -4,94 +4,65 @@ on:
   workflow_call:
     inputs:
       docker-image-name:
+        description: 'The name of your Docker image'
         required: true
         type: string
       docker-build-file-name:
-        default: "Dockerfile"
+        description: 'The filename of a Dockerfile'
+        default: 'Dockerfile'
         required: false
         type: string
       docker-build-context:
-        default: "."
+        description: 'The relative or absolute path to a local directory containing a Dockerfile'
+        default: '.'
         required: false
         type: string
-      cypress-tests-enabled:
-        default: false
-        required: false
-        type: boolean
-      cypress-tests-working-directory:
-        default: "./"
+      docker-build-args:
+        description: 'Specify additional arguments to pass to your Docker image during build time'
         required: false
         type: string
-      cypress-tests-screenshot-path:
-        default: "./"
-        required: false
-        type: string
-      cypress-tests-node-version:
-        default: "18.x"
-        required: false
-        type: string
-      environment-name-development:
-        default: "development"
-        required: false
-        type: string
-      environment-name-staging:
-        default: "staging"
-        required: false
-        type: string
-      environment-name-prod:
-        default: "prod"
+      environment:
+        description: 'Specify the environment you are deploying to'
+        default: 'development'
         required: false
         type: string
     secrets:
       azure-acr-client-id:
         required: true
-        type: string
       azure-acr-secret:
         required: true
-        type: string
       azure-acr-url:
         required: true
-        type: string
       azure-aca-credentials:
         required: true
-        type: string
       azure-aca-name:
         required: true
-        type: string
       azure-aca-resource-group:
         required: true
-        type: string
-      cypress-tests-development-run-command:
-        default: "npm run cy:run -- --env foo='bar'"
-        required: false
-        type: string
-      cypress-tests-staging-run-command:
-        default: "npm run cy:run -- --env foo='bar'"
-        required: false
-        type: string
+
+concurrency:
+  group: ${{ github.ref }}-${{ inputs.environment }}
+  cancel-in-progress: true
 
 jobs:
   set-env:
     name: Set environment variables
     runs-on: ubuntu-22.04
+    outputs:
+      environment: ${{ steps.var.outputs.environment }}
+      branch: ${{ steps.var.outputs.branch }}
+      checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
     steps:
       - id: var
         run: |
           GIT_REF=${{ github.ref }}
           GIT_BRANCH=${GIT_REF##*/}
           INPUT_ENVIRONMENT=${{ inputs.environment }}
-          ENVIRONMENT=${INPUT_ENVIRONMENT}
-          RELEASE=${ENVIRONMENT,,}-`date +%Y-%m-%d`.${{ github.run_number }}
+          ENVIRONMENT=${INPUT_ENVIRONMENT:-"development"}
           CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
           echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
-          echo "release=${RELEASE}" >> $GITHUB_OUTPUT
           echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
-    outputs:
-      environment: ${{ steps.var.outputs.environment }}
-      branch: ${{ steps.var.outputs.branch }}
-      release: ${{ steps.var.outputs.release }}
-      checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
 
   build-and-push-image:
     name: Build and push to ACR
@@ -110,54 +81,26 @@ jobs:
           password: ${{ secrets.azure-acr-secret }}
           registry: ${{ secrets.azure-acr-url }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build and push docker image
         uses: docker/build-push-action@v5
         with:
           context: ${{ inputs.docker-build-context }}
           file: ${{ inputs.docker-build-file-name }}
-          build-args: COMMIT_SHA=${{ needs.set-env.outputs.checked-out-sha }}
+          build-args: |
+            ${{ inputs.docker-build-args }}
+            COMMIT_SHA=${{ needs.set-env.outputs.checked-out-sha }}
           tags: |
             ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:${{ needs.set-env.outputs.branch }}
-            ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:${{ needs.set-env.outputs.release }}
             ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:sha-${{ needs.set-env.outputs.checked-out-sha }}
             ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:latest
           push: true
-
-  create-tag:
-    name: Tag and release
-    needs: set-env
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Create tag
-        run: |
-          git tag ${{ needs.set-env.outputs.release }}
-          git push origin ${{ needs.set-env.outputs.release }}
-
-      - name: Create release
-        uses: "actions/github-script@v6"
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-          script: |
-            try {
-              await github.rest.repos.createRelease({
-                draft: ${{ needs.set-env.outputs.environment == inputs.environment-name-staging || needs.set-env.outputs.environment == inputs.environment-name-development}},
-                generate_release_notes: true,
-                name: "${{ needs.set-env.outputs.release }}",
-                owner: context.repo.owner,
-                prerelease: ${{ needs.set-env.outputs.environment == inputs.environment-name-staging || needs.set-env.outputs.environment == inputs.environment-name-development }},
-                repo: context.repo.repo,
-                tag_name: "${{ needs.set-env.outputs.release }}",
-              });
-            } catch (error) {
-              core.setFailed(error.message);
-            }
+          cache-from: type=gha
 
   deploy-image:
-    name: Deploy to ${{ needs.set-env.outputs.environment }}
+    name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}
     needs: [ build-and-push-image, set-env ]
     runs-on: ubuntu-22.04
     environment: ${{ needs.set-env.outputs.environment }}
@@ -171,48 +114,11 @@ jobs:
         uses: azure/CLI@v1
         id: azure
         with:
-          azcliversion: 2.45.0
+          azcliversion: 2.53.1
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
             az containerapp update \
               --name ${{ secrets.azure-aca-name }} \
               --resource-group ${{ secrets.azure-aca-resource-group }} \
-              --image ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:${{ needs.set-env.outputs.release }} \
+              --image ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:sha-${{ needs.set-env.outputs.checked-out-sha }} \
               --output none
-
-  cypress-tests:
-    name: Run Cypress Tests
-    if: ( needs.set-env.outputs.environment == inputs.environment-name-development || needs.set-env.outputs.environment == inputs.environment-name-staging ) && inputs.cypress-tests-enabled == true
-    needs: [ deploy-image, set-env ]
-    runs-on: ubuntu-22.04
-    environment: ${{ needs.set-env.outputs.environment }}
-    defaults:
-      run:
-        working-directory: ${{ inputs.cypress-tests-working-directory }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.ref }}
-
-      - name: Setup node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.cypress-tests-node-version }}
-
-      - name: Npm install
-        run: npm install
-
-      - name: Run development cypress tests
-        if: ${{ needs.set-env.outputs.environment == inputs.environment-name-development }}
-        run: ${{ secrets.cypress-tests-development-run-command }}
-
-      - name: Run staging cypress tests
-        if: ${{ needs.set-env.outputs.environment == inputs.environment-name-staging }}
-        run: ${{ secrets.cypress-tests-staging-run-command }}
-
-      - name: Upload screenshots
-        if: ${{ failure() }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: screenshots-${{ needs.set-env.outputs.environment }}
-          path: ${{ inputs.cypress-tests-screenshot-path }}


### PR DESCRIPTION
I've removed all of the Cypress specific tests as I'm trying to follow the Single Responsibility Principle. Cypress tests can be chained off this action accordingly, as they are typically different for different services.

I've also added descriptions to the inputs