### PR TITLE
Import image from ACR

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -27,11 +27,9 @@ on:
         required: false
         type: string
     secrets:
-      azure-acr-client-id:
+      azure-acr-credentials:
         required: true
-      azure-acr-secret:
-        required: true
-      azure-acr-url:
+      azure-acr-name:
         required: true
       azure-aca-credentials:
         required: true
@@ -48,6 +46,7 @@ jobs:
       environment: ${{ steps.var.outputs.environment }}
       branch: ${{ steps.var.outputs.branch }}
       checked-out-sha: ${{ steps.var.outputs.checked-out-sha }}
+      github_repository_lc: ${{ steps.var.outputs.github_repository_lc }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,12 +59,14 @@ jobs:
           INPUT_ENVIRONMENT=${{ inputs.environment }}
           ENVIRONMENT=${INPUT_ENVIRONMENT:-"development"}
           CHECKED_OUT_SHA="$(git log -1 '--format=format:%H')"
+          GITHUB_REPOSITORY=${{ github.repository }}
           echo "environment=${ENVIRONMENT,,}" >> $GITHUB_OUTPUT
           echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
           echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
+          echo "github_repository_lc=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
   build-and-push-image:
-    name: Build and push to ACR
+    name: Build and push to GHCR
     needs: set-env
     runs-on: ubuntu-22.04
     environment: ${{ needs.set-env.outputs.environment }}
@@ -74,12 +75,12 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - name: Azure Container Registry login
+      - name: GitHub Container Registry login
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.azure-acr-client-id }}
-          password: ${{ secrets.azure-acr-secret }}
-          registry: ${{ secrets.azure-acr-url }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -94,11 +95,44 @@ jobs:
             COMMIT_SHA=${{ needs.set-env.outputs.checked-out-sha }}
           secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:${{ needs.set-env.outputs.branch }}
-            ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:sha-${{ needs.set-env.outputs.checked-out-sha }}
-            ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:latest
+            ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:${{ needs.set-env.outputs.branch }}
+            ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:sha-${{ needs.set-env.outputs.checked-out-sha }}
+            ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:latest
           push: true
           cache-from: type=gha
+
+  acr-import:
+    name: Import images to ${{ needs.set-env.outputs.environment }} ACR
+    needs: [ build-and-push-image, set-env ]
+    runs-on: ubuntu-22.04
+    environment: ${{ needs.set-env.outputs.environment }}
+    steps:
+      - name: Azure login with ACR credentials
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.azure-acr-credentials }}
+
+      - name: Run ACR Import
+        uses: azure/cli@v2
+        with:
+          azcliversion: 2.40.0
+          inlineScript: |
+            TAGS=(
+              ${{ needs.set-env.outputs.branch }}
+              sha-${{ needs.set-env.outputs.checked-out-sha }}
+              latest
+            )
+            az config set extension.use_dynamic_install=yes_without_prompt
+            for tag in "${TAGS[@]}"
+            do
+              az acr import \
+                --name ${{ secrets.azure-acr-name }} \
+                --source "ghcr.io/${{ needs.set-env.outputs.github_repository_lc }}:$tag" \
+                --image "${{ inputs.docker-image-name }}:$tag" \
+                --username ${{ github.actor }} \
+                --password ${{ secrets.GITHUB_TOKEN }} \
+                --force
+            done
 
   deploy-image:
     name: Deploy '${{ needs.set-env.outputs.branch }}' to ${{ needs.set-env.outputs.environment }}
@@ -121,5 +155,5 @@ jobs:
             az containerapp update \
               --name ${{ secrets.azure-aca-name }} \
               --resource-group ${{ secrets.azure-aca-resource-group }} \
-              --image ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:sha-${{ needs.set-env.outputs.checked-out-sha }} \
+              --image ${{ secrets.azure-acr-name }}.azurecr.io/${{ inputs.docker-image-name }}:sha-${{ needs.set-env.outputs.checked-out-sha }} \
               --output none


### PR DESCRIPTION
* Modifies the workflow, so that the image is pushed to GitHub Container Registry, and then runs an `acr import` on the ACR. The container app update then uses the image from the ACR.
* This allows disabling Public Access on the ACR.
* Rather than specifying url/username/password for the ACR, the `azure-acr-credentials` and `acr-name` secrets will be required.