### PR TITLE
Passed GitHub Secret token to job

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -96,6 +96,7 @@ jobs:
           build-args: |
             ${{ inputs.docker-build-args }}
             COMMIT_SHA=${{ needs.set-env.outputs.checked-out-sha }}
+          secrets: github_token=${{ secrets.GITHUB_TOKEN }}
           tags: |
             ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:${{ needs.set-env.outputs.branch }}
             ${{ secrets.azure-acr-url }}/${{ inputs.docker-image-name }}:sha-${{ needs.set-env.outputs.checked-out-sha }}


### PR DESCRIPTION
This is useful for building Docker images that require a GitHub Token to pull packages from NuGet