### PR TITLE
Poll deployment

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -161,11 +161,58 @@ jobs:
           azcliversion: 2.63.0
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
-            az containerapp update \
+            UPDATE=$(az containerapp update \
               --name ${{ secrets.azure-aca-name }} \
               --resource-group ${{ secrets.azure-aca-resource-group }} \
               --image ${{ secrets.azure-acr-name }}.azurecr.io/${{ inputs.docker-image-name }}:${{ inputs.docker-tag-prefix }}sha-${{ needs.set-env.outputs.checked-out-sha }} \
-              --output none
+              --only-show-errors)
+
+            NEW_REVISION=$(echo "$UPDATE" | jq -r '.properties.latestRevisionName')
+            NEW_TAG=$(echo "$UPDATE" | jq -r '.properties.template.containers[0].image')
+
+            echo "[i] Deploying $NEW_REVISION with image tag $NEW_TAG..."
+
+            HEALTH=""
+            STATE=""
+
+            TIMEOUT=$((SECONDS+60))
+
+            until [[
+              $HEALTH == 'Healthy'
+              && $STATE == 'Provisioned'
+            ]];
+            do
+              REVISION_DETAILS=$(az containerapp revision show \
+                --revision "$NEW_REVISION" \
+                --resource-group "${{ secrets.azure-aca-resource-group }}")
+
+              STATE=$(echo "$REVISION_DETAILS" | jq -r '.properties.provisioningState');
+              HEALTH=$(echo "$REVISION_DETAILS" | jq -r '.properties.healthState');
+              STATUS=$(echo "$REVISION_DETAILS" | jq -r '.properties.runningState');
+              ERROR_MSG=$(echo "$REVISION_DETAILS" | jq -r '.properties.provisioningError')
+
+              echo "[i] Status: $STATE   Health: $HEALTH   State: $STATUS"
+
+              if [[ $HEALTH == 'Unhealthy' ]] && [[ $STATE == 'Failed' ]];
+              then
+                echo "[!] Container App deployment failed!"
+                echo "$ERROR_MSG" >&2
+                exit 1
+              fi
+
+              # Safety condition to avoid unnecessary execution time
+              if [[ $SECONDS -gt $TIMEOUT ]];
+              then
+                echo "[!] Container App failed to reach a steady state after 60 seconds" >&2
+                exit 1
+              fi
+
+              sleep 2
+            done
+
+            # Final output to evidence the state
+            echo "Deployment completed successfully!"
+            exit 0
 
       - name: Create release annotation
         if: inputs.annotate-release

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Run ACR Import
         uses: azure/cli@v2
         with:
-          azcliversion: 2.40.0
+          azcliversion: 2.63.0
           inlineScript: |
             TAGS=(
               ${{ inputs.docker-tag-prefix }}${{ needs.set-env.outputs.branch }}
@@ -158,7 +158,7 @@ jobs:
         uses: azure/CLI@v2
         id: azure
         with:
-          azcliversion: 2.53.1
+          azcliversion: 2.63.0
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
             az containerapp update \
@@ -171,7 +171,7 @@ jobs:
         if: inputs.annotate-release
         uses: azure/CLI@v2
         with:
-          azcliversion: 2.53.1
+          azcliversion: 2.63.0
           inlineScript: |
             APPINSIGHTS_ID=$(az resource show -g ${{ secrets.azure-aca-resource-group }} -n ${{ secrets.azure-aca-resource-group }}-insights --resource-type "microsoft.insights/components" --query id -o tsv)
             UUID=$(cat /proc/sys/kernel/random/uuid)

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Run ACR Import
         uses: azure/cli@v2
         with:
-          azcliversion: 2.63.0
+          azcliversion: cbl-mariner2.0
           inlineScript: |
             TAGS=(
               ${{ inputs.docker-tag-prefix }}${{ needs.set-env.outputs.branch }}
@@ -158,7 +158,7 @@ jobs:
         uses: azure/CLI@v2
         id: azure
         with:
-          azcliversion: 2.63.0
+          azcliversion: cbl-mariner2.0
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
             UPDATE=$(az containerapp update \
@@ -218,7 +218,7 @@ jobs:
         if: inputs.annotate-release
         uses: azure/CLI@v2
         with:
-          azcliversion: 2.63.0
+          azcliversion: cbl-mariner2.0
           inlineScript: |
             APPINSIGHTS_ID=$(az resource show -g ${{ secrets.azure-aca-resource-group }} -n ${{ secrets.azure-aca-resource-group }}-insights --resource-type "microsoft.insights/components" --query id -o tsv)
             UUID=$(cat /proc/sys/kernel/random/uuid)

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -162,9 +162,9 @@ jobs:
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
             UPDATE=$(az containerapp update \
-              --name ${{ secrets.azure-aca-name }} \
-              --resource-group ${{ secrets.azure-aca-resource-group }} \
-              --image ${{ secrets.azure-acr-name }}.azurecr.io/${{ inputs.docker-image-name }}:${{ inputs.docker-tag-prefix }}sha-${{ needs.set-env.outputs.checked-out-sha }} \
+              --name "${{ secrets.azure-aca-name }}" \
+              --resource-group "${{ secrets.azure-aca-resource-group }}" \
+              --image "${{ secrets.azure-acr-name }}.azurecr.io/${{ inputs.docker-image-name }}:${{ inputs.docker-tag-prefix }}sha-${{ needs.set-env.outputs.checked-out-sha }}" \
               --only-show-errors)
 
             NEW_REVISION=$(echo "$UPDATE" | jq -r '.properties.latestRevisionName')

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -180,7 +180,7 @@ jobs:
             until [[
               $HEALTH == 'Healthy'
               && $STATE == 'Provisioned'
-            ]];
+            ]]
             do
               REVISION_DETAILS=$(az containerapp revision show \
                 --revision "$NEW_REVISION" \
@@ -193,7 +193,10 @@ jobs:
 
               echo "[i] Status: $STATE   Health: $HEALTH   State: $STATUS"
 
-              if [[ $HEALTH == 'Unhealthy' ]] && [[ $STATE == 'Failed' ]];
+              if [[
+                $HEALTH == 'Unhealthy'
+                && $STATE == 'Failed'
+              ]]
               then
                 echo "[!] Container App deployment failed!"
                 echo "$ERROR_MSG" >&2
@@ -201,7 +204,7 @@ jobs:
               fi
 
               # Safety condition to avoid unnecessary execution time
-              if [[ $SECONDS -gt $TIMEOUT ]];
+              if [[ $SECONDS -gt $TIMEOUT ]]
               then
                 echo "[!] Container App failed to reach a steady state after 60 seconds" >&2
                 exit 1


### PR DESCRIPTION
I have enhanced the deploy-image step so that it will periodically poll the new revision to determine it's state. This will happen over 30s (deployments typically complete in under 10s). 

This should improve the visibility to engineers if a deployment was to fail