### PR TITLE
Install dependency package

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
+            yum update && yum install jq -y
             az config set extension.use_dynamic_install=yes_without_prompt
             UPDATE=$(az containerapp update \
               --name "${{ secrets.azure-aca-name }}" \


### PR DESCRIPTION
The 'latest' tag for Az CLI now uses Azure Linux docker image which does not ship with 'jq' support.