### PR TITLE
Pin Az CLI version to prevent downstream issues

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Run ACR Import
         uses: azure/cli@v2
         with:
-          azcliversion: latest
+          azcliversion: 2.63.0
           inlineScript: |
             TAGS=(
               ${{ inputs.docker-tag-prefix }}${{ needs.set-env.outputs.branch }}
@@ -158,7 +158,7 @@ jobs:
         uses: azure/CLI@v2
         id: azure
         with:
-          azcliversion: latest
+          azcliversion: 2.63.0
           inlineScript: |
             az config set extension.use_dynamic_install=yes_without_prompt
             UPDATE=$(az containerapp update \
@@ -221,7 +221,7 @@ jobs:
         if: inputs.annotate-release
         uses: azure/CLI@v2
         with:
-          azcliversion: latest
+          azcliversion: 2.63.0
           inlineScript: |
             APPINSIGHTS_ID=$(az resource show -g ${{ secrets.azure-aca-resource-group }} -n ${{ secrets.azure-aca-resource-group }}-insights --resource-type "microsoft.insights/components" --query id -o tsv)
             UUID=$(cat /proc/sys/kernel/random/uuid)


### PR DESCRIPTION
* Using the 'latest' tag is problematic if upstream vendors patch their version with breaking changes, our downstream consumers end up with those changes despite not updating the shared workflow