### PR TITLE
Conditionally use Azure OIDC

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -45,15 +45,23 @@ on:
         required: false
         type: boolean
     secrets:
-      azure-acr-credentials:
-        required: true
-      azure-acr-name:
-        required: true
+      azure-tenant-id:
+        required: false
+      azure-subscription-id:
+        required: false
+      azure-aca-client-id:
+        required: false
       azure-aca-credentials:
-        required: true
+        required: false
       azure-aca-name:
         required: true
       azure-aca-resource-group:
+        required: true
+      azure-acr-client-id:
+        required: false
+      azure-acr-credentials:
+        required: false
+      azure-acr-name:
         required: true
 
 jobs:
@@ -126,7 +134,24 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ needs.set-env.outputs.environment }}
     steps:
+      - name: Azure login with ACR OIDC
+        env:
+          AZURE_TENANT_ID: ${{ secrets.azure-tenant-id || '' }}
+          AZURE_SUBSCRIPTION: ${{ secrets.azure-subscription-id || '' }}
+          AZURE_ACR_CLIENT_ID: ${{ secrets.azure-acr-client-id || '' }}
+        if: env.AZURE_TENANT_ID && env.AZURE_SUBSCRIPTION && env.AZURE_ACR_CLIENT_ID
+        uses: azure/login@v2
+        with:
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+          client-id: ${{ secrets.azure-acr-client-id }}
+
       - name: Azure login with ACR credentials
+        env:
+          AZURE_TENANT_ID: ${{ secrets.azure-tenant-id || '' }}
+          AZURE_SUBSCRIPTION: ${{ secrets.azure-subscription-id || '' }}
+          AZURE_ACR_CLIENT_ID: ${{ secrets.azure-acr-client-id || '' }}
+        if: ${{ !(env.AZURE_TENANT_ID && env.AZURE_SUBSCRIPTION && env.AZURE_ACR_CLIENT_ID) }}
         uses: azure/login@v2
         with:
           creds: ${{ secrets.azure-acr-credentials }}
@@ -160,7 +185,24 @@ jobs:
     runs-on: ubuntu-24.04
     environment: ${{ needs.set-env.outputs.environment }}
     steps:
+      - name: Azure login with ACA OIDC
+        env:
+          AZURE_TENANT_ID: ${{ secrets.azure-tenant-id || '' }}
+          AZURE_SUBSCRIPTION: ${{ secrets.azure-subscription-id || '' }}
+          AZURE_ACA_CLIENT_ID: ${{ secrets.azure-aca-client-id || '' }}
+        if: env.AZURE_TENANT_ID && env.AZURE_SUBSCRIPTION && env.AZURE_ACA_CLIENT_ID
+        uses: azure/login@v2
+        with:
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+          client-id: ${{ secrets.azure-aca-client-id }}
+
       - name: Azure login with ACA credentials
+        env:
+          AZURE_TENANT_ID: ${{ secrets.azure-tenant-id || '' }}
+          AZURE_SUBSCRIPTION: ${{ secrets.azure-subscription-id || '' }}
+          AZURE_ACA_CLIENT_ID: ${{ secrets.azure-aca-client-id || '' }}
+        if: ${{ !(env.AZURE_TENANT_ID && env.AZURE_SUBSCRIPTION && env.AZURE_ACA_CLIENT_ID) }}
         uses: azure/login@v2
         with:
           creds: ${{ secrets.azure-aca-credentials }}

--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ This GitHub Workflow will build a Dockerfile, push it to an Azure Container Regi
 
 ## Usage
 
+* OIDC authorisation (preferred)
+
 ```yml
+permissions:
+  id-token: write # Require write permission to Fetch an OIDC token.
+  contents: read  # Require read permission to read the contents of the repository
+  packages: write # Require write permission to push the image to GHCR
+
 jobs:
   build-push-deploy:
-    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v2.5.0
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.0.0
     with:
       docker-image-name: 'my-app'
       docker-build-file-name: 'Dockerfile'
@@ -16,10 +23,34 @@ jobs:
       environment: development
       annotate-release: true # defaults to false
     secrets:
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSRIPTION_ID }}
       azure-acr-client-id: ${{ secrets.AZURE_ACR_CLIENTID }}
-      azure-acr-secret: ${{ secrets.AZURE_ACR_SECRET }}
-      azure-acr-url: ${{ secrets.AZURE_ACR_URL }}
+      azure-acr-name: ${{ secrets.AZURE_ACR_NAME }}
+      azure-aca-client-id: ${{ secrets.AZURE_ACA_CLIENTID }}
+      azure-aca-name: ${{ secrets.AZURE_ACA_NAME }}
+      azure-aca-resource-group: ${{ secrets.AZURE_ACA_RESOURCE_GROUP }}
+```
+
+* Credential based authorisation
+
+```yml
+jobs:
+  build-push-deploy:
+    uses: DFE-Digital/deploy-azure-container-apps-action/.github/workflows/build-push-deploy.yml@v3.0.0
+    with:
+      docker-image-name: 'my-app'
+      docker-build-file-name: 'Dockerfile'
+      docker-build-context: '.'
+      docker-build-args: 'ENV=development'
+      environment: development
+      annotate-release: true # defaults to false
+    secrets:
+      azure-acr-credentials: ${{ secrets.AZURE_ACR_CREDENTIALS }}
+      azure-acr-client-id: ${{ secrets.AZURE_ACR_CLIENTID }}
+      azure-acr-name: ${{ secrets.AZURE_ACR_NAME }}
       azure-aca-credentials: ${{ secrets.AZURE_ACA_CREDENTIALS }}
+      azure-aca-client-id: ${{ secrets.AZURE_ACA_CLIENTID }}
       azure-aca-name: ${{ secrets.AZURE_ACA_NAME }}
       azure-aca-resource-group: ${{ secrets.AZURE_ACA_RESOURCE_GROUP }}
 ```


### PR DESCRIPTION
* https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure-openid-connect
* This allows us to use Managed Identities, configured with a Federated Identity to trust tokens generated by GitHub. GitHub actions will then be given permissions defined in the role associated with the managed identity.
* To use OIDC, the `azure-tenant-id`, `azure-subscription-id`, `azure-acr-client-id` and `azure-aca-client-id` secrets need to be set. Only when they are set, will OIDC be preferred over credential based authorisation.