### PR TITLE
Annotate release condition evaluation is now fixed

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -29,9 +29,8 @@ inputs:
     required: true
   annotate-release:
     description: 'Annotate the release in App Insights?'
-    default: false
+    default: 'no'
     required: false
-    type: boolean
   app-insights-name:
     description: 'Name of App Insights resource'
     required: false
@@ -175,7 +174,7 @@ runs:
           echo "$RESULT"
 
     - name: Create release annotation
-      if: inputs.annotate-release
+      if: ${{ inputs.annotate-release == 'yes' }}
       uses: azure/CLI@v2
       with:
         azcliversion: ${{ inputs.azure-cli-version }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Combine all composite actions together for a simple deployment workflow
           azure-aca-name: ${{ secrets.ACA_CONTAINERAPP_NAME }}
           azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
           azure-acr-name: ${{ secrets.ACR_NAME }}
-          annotate-release: true
+          annotate-release: 'yes'
           image-name: my-image
 ```
 
@@ -96,6 +96,6 @@ Or run certain steps in a matrix when dealing with things like worker or init co
           azure-aca-name: ${{ secrets.ACA_CONTAINERAPP_NAME }}
           azure-aca-resource-group: ${{ secrets.ACA_RESOURCE_GROUP }}
           azure-acr-name: ${{ secrets.ACR_NAME }}
-          annotate-release: true
+          annotate-release: 'yes'
           image-name: my-cool-app
 ```


### PR DESCRIPTION
* Boolean input types were not working properly and evaluating as 'truthy'. Using a string input type aligns it to the github workflow schema