### PR TITLE
Artifact Attestation for Image Builds

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -57,6 +57,7 @@ runs:
       uses: docker/setup-buildx-action@v3
 
     - name: Build and push Docker image
+      id: build
       uses: docker/build-push-action@v6
       with:
         context: ${{ inputs.build-context }}
@@ -72,6 +73,15 @@ runs:
           ghcr.io/${{ steps.var.outputs.github-repository-lc }}:${{ inputs.tag-prefix }}latest
         push: true
         cache-from: type=gha
+
+    - name: Generate artifact attestation
+      uses: actions/attest-build-provenance@v2
+      id: attest
+      with:
+        subject-name: ghcr.io/${{ steps.var.outputs.github-repository-lc }}
+        subject-digest: ${{ steps.build.outputs.digest }}
+        push-to-registry: true
+        github-token: ${{ inputs.github-token }}
 
     - name: Set summary
       shell: bash


### PR DESCRIPTION
Publish artifact attestation along with the container image digest to GitHub Container Registry.

This metadata bundle helps to validate the providence of the source code used to build the container image.

Read: https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations/using-artifact-attestations-to-establish-provenance-for-builds