### PR TITLE
Generate OCI metadata for Docker build step

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -97,11 +97,3 @@ runs:
         subject-digest: ${{ steps.build.outputs.digest }}
         push-to-registry: true
         github-token: ${{ inputs.github-token }}
-
-    - name: Set summary
-      shell: bash
-      run: |
-        echo "### Built 🛠️" >> $GITHUB_STEP_SUMMARY
-        echo "- **Digest:** ${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Tags:** ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
-        echo "- **Labels:** ${{ steps.meta.outputs.labels }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -56,6 +56,22 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 
+    - name: Generate metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          name=ghcr.io/${{ steps.var.outputs.github-repository-lc }}
+        labels: |
+          org.opencontainers.image.vendor=Department for Education
+          org.opencontainers.image.created={{commit_date 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'}}
+        flavor: |
+          latest=true
+          prefix=${{ inputs.tag-prefix }}
+        tags: |
+          type=sha,prefix=${{ inputs.tag-prefix }}sha-,format=long
+          type=ref,event=branch
+
     - name: Build and push Docker image
       id: build
       uses: docker/build-push-action@v6
@@ -67,10 +83,9 @@ runs:
           ${{ inputs.build-args }}
           COMMIT_SHA=${{ steps.var.outputs.checked-out-sha }}
         secrets: github_token=${{ inputs.github-token }}
-        tags: |
-          ghcr.io/${{ steps.var.outputs.github-repository-lc }}:${{ inputs.tag-prefix }}${{ steps.var.outputs.branch }}
-          ghcr.io/${{ steps.var.outputs.github-repository-lc }}:${{ inputs.tag-prefix }}sha-${{ steps.var.outputs.checked-out-sha }}
-          ghcr.io/${{ steps.var.outputs.github-repository-lc }}:${{ inputs.tag-prefix }}latest
+        labels: ${{ steps.meta.outputs.labels }}
+        tags: ${{ steps.meta.outputs.tags }}
+        annotations: ${{ steps.meta.outputs.annotations }}
         push: true
         cache-from: type=gha
 
@@ -87,6 +102,6 @@ runs:
       shell: bash
       run: |
         echo "### Built 🛠️" >> $GITHUB_STEP_SUMMARY
-        echo "- ghcr.io/${{ steps.var.outputs.github-repository-lc }}:${{ inputs.tag-prefix }}${{ steps.var.outputs.branch }}" >> $GITHUB_STEP_SUMMARY
-        echo "- ghcr.io/${{ steps.var.outputs.github-repository-lc }}:${{ inputs.tag-prefix }}sha-${{ steps.var.outputs.checked-out-sha }}" >> $GITHUB_STEP_SUMMARY
-        echo "- ghcr.io/${{ steps.var.outputs.github-repository-lc }}:${{ inputs.tag-prefix }}latest" >> $GITHUB_STEP_SUMMARY
+        echo "- **Digest:** ${{ steps.build.outputs.digest }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Tags:** ${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+        echo "- **Labels:** ${{ steps.meta.outputs.labels }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/actions/import/action.yml
+++ b/.github/actions/import/action.yml
@@ -49,7 +49,7 @@ runs:
         GITHUB_REPOSITORY=${{ github.repository }}
         echo "branch=$GIT_BRANCH" >> $GITHUB_OUTPUT
         echo "checked-out-sha=${CHECKED_OUT_SHA}" >> $GITHUB_OUTPUT
-        echo "github_repository_lc=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
+        echo "github-repository-lc=${GITHUB_REPOSITORY,,}" >> $GITHUB_OUTPUT
 
     - name: Login with OIDC
       if: env.AZURE_TENANT_ID && env.AZURE_SUBSCRIPTION && env.AZURE_ACR_CLIENT_ID
@@ -65,27 +65,39 @@ runs:
       with:
         creds: ${{ inputs.azure-acr-credentials }}
 
+    - name: Generate metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          name=ghcr.io/${{ steps.var.outputs.github-repository-lc }}
+        flavor: |
+          latest=true
+          prefix=${{ inputs.tag-prefix }}
+        tags: |
+          type=sha,prefix=${{ inputs.tag-prefix }}sha-,format=long
+          type=ref,event=branch
+
     - name: Import to ACR
       uses: azure/cli@v2
       with:
         azcliversion: ${{ inputs.azure-cli-version }}
         inlineScript: |
           TAGS=(
-            ${{ inputs.tag-prefix }}${{ steps.var.outputs.branch }}
-            ${{ inputs.tag-prefix }}sha-${{ steps.var.outputs.checked-out-sha }}
-            ${{ inputs.tag-prefix }}latest
+            ${{ steps.meta.outputs.tags }}
           )
           az config set extension.use_dynamic_install=yes_without_prompt
           echo "### Imported 📥" >> $GITHUB_STEP_SUMMARY
           for tag in "${TAGS[@]}"
           do
+            suffix="${tag#*:}"
             az acr import \
               --name ${{ inputs.azure-acr-name }} \
-              --source "ghcr.io/${{ steps.var.outputs.github_repository_lc }}:$tag" \
-              --image "${{ inputs.image-name }}:$tag" \
+              --source "$tag" \
+              --image "${{ inputs.image-name }}:$suffix" \
               --username ${{ github.actor }} \
               --password ${{ inputs.github-token }} \
               --force
-            echo "[i] Imported: ${{ inputs.azure-acr-name }}.azurecr.io/${{ inputs.image-name }}:$tag"
-            echo "- ${{ inputs.azure-acr-name }}.azurecr.io/${{ inputs.image-name }}:$tag" >> $GITHUB_STEP_SUMMARY
+            echo "[i] Imported: ${{ inputs.azure-acr-name }}.azurecr.io/${{ inputs.image-name }}:$suffix"
+            echo "- ${{ inputs.azure-acr-name }}.azurecr.io/${{ inputs.image-name }}:$suffix" >> $GITHUB_STEP_SUMMARY
           done


### PR DESCRIPTION
- The `metadata` action can generate appropriate tags, labels and annotations based on the Dockerfile OCI metadata standard. We can then use that in the subsequent step that pushes to the container registry so we don't need to fiddle around trying to generate our own tags.
- There is no regression as the generated tags are configured to fit with our existing patterns of `latest` `<branch-name>` and `sha-<sha>`